### PR TITLE
teamID should be teamId

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ The first 4 digits identify the season of the game (ie. 2017 for the 2017-2018 s
 
 `?expand=schedule.ticket` Provides the different places to buy tickets for the upcoming games
 
-`?teamID=30` Limit results to a specific team. Team ids can be found through the teams endpoint
+`?teamId=30` Limit results to a specific team. Team ids can be found through the teams endpoint
 
 `?startDate=2018-01-09` Start date for the search
 


### PR DESCRIPTION
The query string is case sensitive and it is a good idea to make sure there isn't conclusion. Also review the `?expand=team.schedule.previous` schedule modifier because it doesn't modify anything for me